### PR TITLE
Update Day 50 - Windows Remote Management Command Targeting a Remote …

### DIFF
--- a/100DaysOfKQL/Day 50 - Windows Remote Management Command Targeting a Remote Endpoint.md
+++ b/100DaysOfKQL/Day 50 - Windows Remote Management Command Targeting a Remote Endpoint.md
@@ -56,9 +56,9 @@ DeviceEvents
 ### Microsoft Defender for Endpoint via DeviceProcessEvents ###
 ```KQL
 DeviceProcessEvents
-| where (FileName =~ "winrs.exe" and ProcessCommandLine has_any ("/r:", "/remote:")
+| where (FileName =~ "winrs.exe" and ProcessCommandLine has_any ("/r:", "/remote:"))
     or (FileName =~ "wmic.exe" and ProcessCommandLine has "/node:")
-    or (FileName in~ ("powershell.exe", "pwsh.exe") and ProcessCommandLine has_any ("Enter-PSSession", "New-PSSession", "Invoke-Command")
+    or (FileName in~ ("powershell.exe", "pwsh.exe") and ProcessCommandLine has_any ("Enter-PSSession", "New-PSSession", "Invoke-Command"))
 ```
 ## Microsoft Sentinel ##
 ### Microsoft Defender for Endpoint via DeviceEvents ###
@@ -70,7 +70,7 @@ DeviceEvents
 ### Microsoft Defender for Endpoint via DeviceProcessEvents ###
 ```KQL
 DeviceProcessEvents
-| where (FileName =~ "winrs.exe" and ProcessCommandLine has_any ("/r:", "/remote:")
+| where (FileName =~ "winrs.exe" and ProcessCommandLine has_any ("/r:", "/remote:"))
     or (FileName =~ "wmic.exe" and ProcessCommandLine has "/node:")
-    or (FileName in~ ("powershell.exe", "pwsh.exe") and ProcessCommandLine has_any ("Enter-PSSession", "New-PSSession", "Invoke-Command")
+    or (FileName in~ ("powershell.exe", "pwsh.exe") and ProcessCommandLine has_any ("Enter-PSSession", "New-PSSession", "Invoke-Command"))
 ```


### PR DESCRIPTION
…Endpoint.md

Corrected parenthesis syntax in the two DeviceProcessEvents queries, adding a closing ')' to the end of lines 2 and 4 (for both examples).