### PR TITLE
Rename Cert Central to The Cert Graveyard

### DIFF
--- a/Defender for Endpoint/ExternalData - Cert Central, CertReport.md
+++ b/Defender for Endpoint/ExternalData - Cert Central, CertReport.md
@@ -1,4 +1,4 @@
-# *ExternalData - Cert Central, CertReport*
+# *ExternalData - The Cert Graveyard, CertReport*
 
 ## Query Information
 
@@ -17,9 +17,9 @@
 
 #### Description
 
-This query looks up files involved in DeviceProcessEvents, DeviceFileEvents or DeviceImageLoadEvents from a user's Downloads folder, or a subfolder in %APPDATA% or %LOCALAPPDATA% against the Cert Central/CertReport DB CSV export.
+This query looks up files involved in DeviceProcessEvents, DeviceFileEvents or DeviceImageLoadEvents from a user's Downloads folder, or a subfolder in %APPDATA% or %LOCALAPPDATA% against the The Cert Graveyard/CertReport DB CSV export.
 
-The goal of this query is to identify processes or files that are signed with certs present in Cert Central. The match is made on the Signer field, because multiple certificates can be assigned to a Signer, but not all of them will be in CertReport (e.g.: they haven't been reported yet).
+The goal of this query is to identify processes or files that are signed with certs present in The Cert Graveyard. The match is made on the Signer field, because multiple certificates can be assigned to a Signer, but not all of them will be in CertReport (e.g.: they haven't been reported yet).
 
 The CertSerialMatchesCertReport column, with a value of TRUE or FALSE, will return whether the serial of the certificate in DeviceFileCertificateInfo matches the one in CertReport. If this returns TRUE, it means that the cert has been reported in CertReport and therefore, there are high chances that this file is malicious. If it returns FALSE, it means that there's only been a match on the Signer (e.g.: BLACK INDIGO LTD) but the serial from the file in MDE didn't match one in CertReport. At this point, you should investigate the file further to see if it's malicious or not. If it is, it may be signed with a new certificate that isn't in CertReport yet.
 
@@ -39,7 +39,7 @@ Since "matches regex" is used to identify files at certain paths, depending on t
 ### References ###
 
 - https://x.com/SquiblydooBlog/status/1934975511156941247
-- https://certcentral.org/
+- https://certgraveyard.org/
 
 ### Queries Overview ###
 
@@ -49,7 +49,7 @@ Since "matches regex" is used to identify files at certain paths, depending on t
 ### Defender for Endpoint (MDE) via DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents (ALL-IN-ONE QUERY) ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 union DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents
@@ -66,7 +66,7 @@ union DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents
 ### Defender for Endpoint (MDE) via DeviceProcessEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceProcessEvents
@@ -83,7 +83,7 @@ DeviceProcessEvents
 ### Defender for Endpoint (MDE) via DeviceImageLoadEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceImageLoadEvents
@@ -100,7 +100,7 @@ DeviceImageLoadEvents
 ### Defender for Endpoint (MDE) via DeviceFileEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceFileEvents
@@ -117,7 +117,7 @@ DeviceFileEvents
 ### Defender for Endpoint (MDE) via DeviceFileCertificateInfo, DeviceProcessEvents, DeviceEvents
 ```KQL
 let CertReport = let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
     | extend CRSerial = tolower(CRSerial);
 let PresentCertificateSigners = materialize(
@@ -125,7 +125,7 @@ let PresentCertificateSigners = materialize(
     | distinct Signer, CertificateSerialNumber
     | join CertReport on $left.Signer == $right.CRSigner
     | extend CertSerialMatchesCertReport = iif( CertificateSerialNumber == CRSerial, "TRUE", "FALSE")
-    // If you only want to match on Signer name, which is more suited for hunting potential new certificate rather than detecting files with known Signers in Cert Central, change the value to FALSE.
+    // If you only want to match on Signer name, which is more suited for hunting potential new certificate rather than detecting files with known Signers in The Cert Graveyard, change the value to FALSE.
     | where CertSerialMatchesCertReport == "TRUE"
     | distinct Signer);
 let Hashes = materialize (
@@ -142,7 +142,7 @@ Files
 ### Defender for Endpoint (MDE) via DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents (ALL-IN-ONE QUERY) ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 union DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents
@@ -159,7 +159,7 @@ union DeviceProcessEvents, DeviceImageLoadEvents, DeviceFileEvents
 ### Defender for Endpoint (MDE) via DeviceProcessEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceProcessEvents
@@ -176,7 +176,7 @@ DeviceProcessEvents
 ### Defender for Endpoint (MDE) via DeviceImageLoadEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceImageLoadEvents
@@ -193,7 +193,7 @@ DeviceImageLoadEvents
 ### Defender for Endpoint (MDE) via DeviceFileEvents ###
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
 | extend CRSerial = tolower(CRSerial);
 DeviceFileEvents
@@ -210,7 +210,7 @@ DeviceFileEvents
 ### Defender for Endpoint (MDE) via DeviceFileCertificateInfo, DeviceProcessEvents, DeviceEvents
 ```KQL
 let CertReport = (externaldata(CRHash:string, CRMalware: string, CRMalwareType: string, CRMalwareNotes: string, CRSigner: string, CRIssuerShort: string, CRIssuer: string, CRSerial: string, CRThumbprint: string, CRValidFrom: datetime, CRValidTo: datetime, CRCountry: string, CRState: string, CRLocality: string, CREmail: string, CRRDNSerialNumber: string)
-[@"https://certcentral.org/api/download_csv"]
+[@"https://certgraveyard.org/api/download_csv"]
 with (format=csv, ignoreFirstRecord=true))
     | extend CRSerial = tolower(CRSerial);
 let PresentCertificateSigners = materialize(
@@ -218,7 +218,7 @@ let PresentCertificateSigners = materialize(
     | distinct Signer, CertificateSerialNumber
     | join CertReport on $left.Signer == $right.CRSigner
     | extend CertSerialMatchesCertReport = iif( CertificateSerialNumber == CRSerial, "TRUE", "FALSE")
-    // If you only want to match on Signer name, which is more suited for hunting potential new certificate rather than detecting files with known Signers in Cert Central, change the value to FALSE.
+    // If you only want to match on Signer name, which is more suited for hunting potential new certificate rather than detecting files with known Signers in The Cert Graveyard, change the value to FALSE.
     | where CertSerialMatchesCertReport == "TRUE"
     | distinct Signer);
 let Hashes = materialize (


### PR DESCRIPTION
Updated references from Cert Central to The Cert Graveyard and ertcentral.org to certgraveyard.org